### PR TITLE
Fix for clojurephant/clojurephant#164

### DIFF
--- a/src/test/clojure/math/calc_test.clj
+++ b/src/test/clojure/math/calc_test.clj
@@ -1,4 +1,4 @@
-(ns math.calc_test
+(ns math.calc-test
   (:require [clojure.test :refer :all]
             [math.calc :refer :all]))
 


### PR DESCRIPTION
Clojure has an odd mismatch where namespaces use "-", but they need to be replaced with "_" in the file names (for java reasons). This isn't really a clojurephant issue, just a stumbling block with Clojure hosted on the JVM.